### PR TITLE
Change from ENV to JSON

### DIFF
--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -1,14 +1,12 @@
 const serverCommands = require('../server.js');
 const Discord = require('discord.js')
-var BOT_PREFIX = ''
-
-serverCommands.getValues('../')
 
 const CHANNELS = {
     'stopStudyChannel': '882783531531653210'
 }
 
 exports.study = async (message, args, guildRoles) => {
+    BOT_PREFIX = message['__BOT_PREFIX']
     if(!typeof([args][0], 'int') && args)
     {
         message.reply(`To enter study mode:\n${BOT_PREFIX}study`)

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -1,5 +1,7 @@
 const serverCommands = require('../server.js');
 const Discord = require('discord.js')
+const fs = require('fs');
+const path = require('path');
 
 const CHANNELS = {
     'stopStudyChannel': '882783531531653210'
@@ -37,5 +39,19 @@ exports.ping = (message, args) => {
 }
 
 exports.set = (message, args, guildRoles) => {
-    serverCommands.changeEnvInfo('BOT_PREFIX', args[0])
+    // Check if Authorisation is correct
+    if(!message.member.roles.cache.some(r => r.name === 'Admin'))
+    {
+        message.reply('You do not have authorisation!')
+        return 0
+    }
+
+    // Check if the parameter is valid (e.g prefix etc)
+    
+    const valuesData = JSON.parse(fs.readFileSync(path.join(__dirname + '/../values.json')))
+    if(!valuesData[`${args[0]}`]) return 0 // Value not in JSON File
+
+    // Change the value
+    serverCommands.changeEnvInfo(args[0], args[1])
+
 }

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -43,13 +43,13 @@ exports.set = (message, args, guildRoles) => {
     if(!message.member.roles.cache.some(r => r.name === 'Admin'))
     {
         message.reply('You do not have authorisation!')
-        return 0
+        return
     }
 
     // Check if the parameter is valid (e.g prefix etc)
     
     const valuesData = JSON.parse(fs.readFileSync(path.join(__dirname + '/../values.json')))
-    if(!valuesData[`${args[0]}`]) return 0 // Value not in JSON File
+    if(!valuesData[`${args[0]}`]) return // Value not in JSON File
 
     // Change the value
     serverCommands.changeEnvInfo(args[0], args[1])

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -1,20 +1,20 @@
-require('dotenv').config()
-const { BOT_PREFIX } = process.env
+const serverCommands = require('../server.js');
 const Discord = require('discord.js')
+var BOT_PREFIX = ''
+
+serverCommands.getValues('../')
 
 const CHANNELS = {
     'stopStudyChannel': '882783531531653210'
 }
 
-const changeEnv = require('../server.js')
-
 exports.study = async (message, args, guildRoles) => {
     if(!typeof([args][0], 'int') && args)
     {
         message.reply(`To enter study mode:\n${BOT_PREFIX}study`)
-        return 0
+        return
     }
-    
+
     message.author.send('You\'re now studying!')
 
     message.guild.channels.cache.get(CHANNELS.stopStudyChannel).send(`Welcome ${message.author} to Study Mode. Type \`${BOT_PREFIX}stop\` to end the session.`)
@@ -26,17 +26,18 @@ exports.study = async (message, args, guildRoles) => {
 }
 
 exports.stop = async (message, args, guildRoles) => {
-    if (message.channelId !== CHANNELS.stopStudyChannel) return 0 // Command should only work inside the stop-study channel
+    if (message.channelId !== CHANNELS.stopStudyChannel) return // Command should only work inside the stop-study channel
     guildRoles.forEach(async (r) => {
         if(r.role.name === 'Studying') await message.member.roles.remove(r.role.id)
     })
 
     message.author.send('Study Mode Ended!')
 }
+
 exports.ping = (message, args) => {
     console.log('Pong!')
 }
 
 exports.set = (message, args, guildRoles) => {
-    changeEnv('BOT_PREFIX', args[0])
+    serverCommands.changeEnvInfo('BOT_PREFIX', args[0])
 }

--- a/server.js
+++ b/server.js
@@ -1,8 +1,6 @@
-require('dotenv').config()
-const { TOKEN, BOT_PREFIX } = process.env
 const fs = require('fs')
 
-const { Client, Intents, Collection, Role } = require('discord.js')
+const { Client, Intents, Role } = require('discord.js')
 
 const botIntentList = new Intents()
 botIntentList.add(
@@ -15,23 +13,40 @@ const client = new Client({ intents: botIntentList })
 const commands = require('./scripts/commands.js');
 const Roles = {}
 
-const changeEnvInfo = (row, data) => {
-    envData = fs.readFileSync('./.env').toString().trim().split('\n')
-    tmp = ''
-    
-    for ( const [index, line] of envData.entries())
-    {
-        line.split(' = ')[0] === row ? tmp += `${row} = ${data}\n` : tmp += `${line}\n`
-    }
 
-    fs.writeFileSync('./.env', tmp.toString())
-    console.log('Changed a value in .env')
+// Load TOKEN and Prefix
+
+var TOKEN = ''
+var BOT_PREFIX = ''
+
+const getValues = (path) => {
+    fileData = JSON.parse(fs.readFileSync(`${path}values.json`));
+    
+    TOKEN = fileData['TOKEN']
+    BOT_PREFIX = fileData['BOT_PREFIX']
+    
+    return
 }
 
+getValues('./')
+
+
+const changeEnvInfo = (row, data) => {
+    const fileData = JSON.parse(fs.readFileSync('./values.json'))
+    if(fileData[row])
+    {
+        fileData[row] = data
+        fs.writeFileSync('./values.json', JSON.stringify(fileData)) // Rewrite data
+        // Re read
+        getValues()
+    }
+    return
+}
 client.once('ready', (c) => {
     
     c.guilds.cache.find(g => {
         Roles[`${g.id}`] = []
+
         g.roles.cache.find(r => {
             Roles[`${g.id}`].push({
                 role: r
@@ -47,11 +62,14 @@ client.on('messageCreate', (message) => {
     if (message.content.startsWith(BOT_PREFIX))
     {
         // Get Command
-        let [command, args]= message.content.slice(1, message.content.length).split(' ')
+        let [command, args] = message.content.slice(1, message.content.length).split(' ')
         if(commands[command]) (commands[command](message, args, Roles[message.member.guild.id]))
     }
 })
 
 client.login(TOKEN)
 
+exports.getValues = function(){
+    console.log('Hello')
+}
 exports.changeEnvInfo = changeEnvInfo

--- a/server.js
+++ b/server.js
@@ -62,8 +62,10 @@ client.on('messageCreate', (message) => {
     if (message.content.startsWith(BOT_PREFIX))
     {
         // Get Command
-        let [command, args] = message.content.slice(1, message.content.length).split(' ')
-
+        const userCommand = message.content.slice(BOT_PREFIX.length, message.content.length).split(' ')
+        const command = userCommand[0]
+        const args = userCommand.slice(1)
+        
         // Bundle PREFIX with Message - easier to access on `commands.js`
         message['__BOT_PREFIX'] = BOT_PREFIX
 

--- a/server.js
+++ b/server.js
@@ -38,7 +38,7 @@ const changeEnvInfo = (row, data) => {
         fileData[row] = data
         fs.writeFileSync('./values.json', JSON.stringify(fileData)) // Rewrite data
         // Re read
-        getValues()
+        getValues('./')
     }
     return
 }
@@ -63,6 +63,11 @@ client.on('messageCreate', (message) => {
     {
         // Get Command
         let [command, args] = message.content.slice(1, message.content.length).split(' ')
+
+        // Bundle PREFIX with Message - easier to access on `commands.js`
+        message['__BOT_PREFIX'] = BOT_PREFIX
+
+        // If the command is valid, run the function and pass the message, arguments and roles for the server
         if(commands[command]) (commands[command](message, args, Roles[message.member.guild.id]))
     }
 })


### PR DESCRIPTION
# Changes
- Changed from using `.env` to `.json` to store the important values for the bot.
- Added function for server admins to configure pre-existing values in `values.json` such as bot prefix
## Why?
- Easier to read & write data
- Values inside the server can be refreshed by re-reading the JSON file rather than restarting the server (didn't figure out how to do it simply with the `.env` file)
---