### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @TobyBridle @obfuscatedgenerated


### PR DESCRIPTION
A CODEOWNERS file means that the owners of specified directories and/or files are requested for review automatically on PRs that affect them. I've specified * to @TobyBridle and @obfuscatedgenerated so we can review external PRs. We could also consider adding CODEOWNERS entries for authors of individual commands (via the js modules) if need be.